### PR TITLE
Feat: Add share from receive screen, improve home and receive design

### DIFF
--- a/app/src/main/java/com/example/ethktprototype/composables/ReceiveBottomSheet.kt
+++ b/app/src/main/java/com/example/ethktprototype/composables/ReceiveBottomSheet.kt
@@ -1,5 +1,6 @@
 package com.example.ethktprototype.composables
 
+import android.content.Intent
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -7,13 +8,12 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
@@ -21,14 +21,11 @@ import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.example.ethktprototype.R
 
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -38,7 +35,6 @@ fun ReceiveBottomSheet(
     onDismiss: () -> Unit,
 ) {
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
-    val clipboardManager = LocalClipboardManager.current
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -50,36 +46,46 @@ fun ReceiveBottomSheet(
     ) {
         Column(
             modifier = Modifier
-                .fillMaxSize(),
+                .fillMaxSize().padding(16.dp),
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center
         ) {
+            Spacer(modifier = Modifier.weight(1f))
+
             QRCodeDisplay(data = walletAddress)
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.Center,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Text(
-                    text = walletAddress.take(6) + "..." + walletAddress.takeLast(4),
-                    fontSize = 18.sp,
+            Spacer(modifier = Modifier.height(16.dp))
+             Text(
+                    text = walletAddress.take(10) + "..." + walletAddress.takeLast(4),
+                    fontSize = 20.sp,
                     fontWeight = FontWeight.Medium,
                     textAlign = TextAlign.Center
                 )
-                Spacer(modifier = Modifier.width(8.dp))
-                IconButton(
-                    onClick = {
-                        clipboardManager.setText(AnnotatedString(walletAddress))
-                    }
+                Spacer(modifier = Modifier.weight(1f))
+
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                val sendIntent: Intent = Intent().apply {
+                    action = Intent.ACTION_SEND
+                    putExtra(Intent.EXTRA_TEXT, walletAddress)
+                    type = "text/plain"
+                }
+                val shareIntent = Intent.createChooser(sendIntent, null)
+                val context = LocalContext.current
+                Button(
+                    modifier = Modifier.fillMaxWidth(),
+                    onClick = {context.startActivity(shareIntent)},
+                    enabled = true,
                 ) {
-                    Icon(
-                        painter = painterResource(id = R.drawable.baseline_content_copy_24),
-                        contentDescription = "Copy",
-                        modifier = Modifier.size(20.dp),
-                        tint = MaterialTheme.colorScheme.primary
+                    Text(
+                        modifier = Modifier.padding(vertical = 10.dp),
+                        fontSize = 20.sp,
+                        text = "Share"
                     )
                 }
             }
+            }
         }
     }
-}

--- a/app/src/main/java/com/example/ethktprototype/screens/WalletHomeScreen.kt
+++ b/app/src/main/java/com/example/ethktprototype/screens/WalletHomeScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -33,7 +32,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -86,9 +84,21 @@ fun TokenListScreen(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(16.dp, 0.dp)
-                .wrapContentHeight()
+                .wrapContentHeight(),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            Spacer(Modifier.weight(1f))
+            Text(
+                text = uiState.ens.ifEmpty {
+                    uiState.walletAddress.take(5) + "..." + uiState.walletAddress.takeLast(
+                        4
+                    )
+                },
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurface,
+                fontWeight = FontWeight.Medium,
+                fontSize = 18.sp
+            )
+            Spacer(modifier = Modifier.weight(1f))
             IconButton(
                 modifier = Modifier.size(30.dp),
                 onClick = { navController.navigate("settingsScreen") }
@@ -113,7 +123,7 @@ fun TokenListScreen(
                 fontWeight = FontWeight.Bold,
                 fontSize = 50.sp
             )
-            Spacer(modifier = Modifier.height(16.dp))
+//            Spacer(modifier = Modifier.height(8.dp))
         }
 
         Row(
@@ -122,40 +132,6 @@ fun TokenListScreen(
                 .padding(horizontal = 16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = uiState.ens.ifEmpty {
-                        uiState.walletAddress.take(5) + "..." + uiState.walletAddress.takeLast(
-                            4
-                        )
-                    },
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f),
-                    fontWeight = FontWeight.Medium,
-                    fontSize = 16.sp
-                )
-                if (uiState.ens.isNotEmpty()) {
-                    Text(
-                        text = uiState.walletAddress.take(5) + "..." + uiState.walletAddress.takeLast(
-                            4
-                        ),
-                        style = MaterialTheme.typography.bodySmall,
-                        color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.6f),
-                        fontSize = 12.sp
-                    )
-                }
-            }
-            IconButton(
-                onClick = {
-                    clipboardManager.setText(AnnotatedString(uiState.walletAddress))
-                }
-            ) {
-                Icon(
-                    Icons.Filled.ContentCopy,
-                    contentDescription = "Copy wallet address",
-                    tint = MaterialTheme.colorScheme.primary
-                )
-            }
         }
 
         Spacer(modifier = Modifier.height(8.dp))


### PR DESCRIPTION
## Changes
- Implement [Android Sharesheet](https://developer.android.com/training/sharing/send#why-to-use-system-sharesheet) to allow simple sharing of wallet address
- Improve Share and wallet home screen designs

## Screenshots

<img height="400" width="200" src="https://github.com/user-attachments/assets/1553c5df-d96a-418c-bb6a-686483c4d262" />

| Before | After |
|--------|-------|
| <img src="https://github.com/user-attachments/assets/15f2ca03-feec-44b8-af12-b2c65cf7049b" width="350" height="300" />|  <img src="https://github.com/user-attachments/assets/a7e02944-81d4-4b80-bece-695f8d2b89ec" width="350" height="300" />|

